### PR TITLE
Merge community fork

### DIFF
--- a/xDSCResourceDesigner.psd1
+++ b/xDSCResourceDesigner.psd1
@@ -1,6 +1,6 @@
 @{
 # Version number of this module.
-ModuleVersion = '1.1.1.2'
+ModuleVersion = '1.1.1.3'
 
 # ID used to uniquely identify this module
 GUID = '74951b31-1aa5-472b-9109-738de1bca38f'

--- a/xDSCResourceDesigner.psd1
+++ b/xDSCResourceDesigner.psd1
@@ -1,6 +1,6 @@
 @{
 # Version number of this module.
-ModuleVersion = '1.1.1.3'
+ModuleVersion = '1.1.1.2'
 
 # ID used to uniquely identify this module
 GUID = '74951b31-1aa5-472b-9109-738de1bca38f'

--- a/xDscResourceDesigner.Tests.ps1
+++ b/xDscResourceDesigner.Tests.ps1
@@ -1,0 +1,115 @@
+#requires -RunAsAdministrator
+# Test-xDscResource requires administrator privileges, so we may as well enforce that here.
+
+end
+{
+    Remove-Module [x]DscResourceDesigner -Force
+    Import-Module $PSScriptRoot\xDscResourceDesigner.psd1 -ErrorAction Stop
+
+    Describe Test-xDscResource {
+        Context 'A module with a psm1 file but no matching schema.mof' {
+            Setup -Dir TestResource
+            Setup -File TestResource\TestResource.psm1 -Content (Get-TestDscResourceModuleContent)
+
+            It 'Should fail the test' {
+                Test-xDscResource -Name $TestDrive\TestResource | Should Be $false
+            }
+        }
+
+        Context 'A module with a schema.mof file but no psm1 file' {
+            Setup -Dir TestResource
+            Setup -File TestResource\TestResource.schema.mof -Content (Get-TestDscResourceSchemaContent)
+
+            It 'Should fail the test' {
+                Test-xDscResource -Name $TestDrive\TestResource | Should Be $false
+            }
+        }
+
+        Context 'A resource with both required files, valid contents' {
+            Setup -Dir TestResource
+            Setup -File TestResource\TestResource.schema.mof -Content (Get-TestDscResourceSchemaContent)
+            Setup -File TestResource\TestResource.psm1 -Content (Get-TestDscResourceModuleContent)
+
+            It 'Should pass the test' {
+                Test-xDscResource -Name $TestDrive\TestResource | Should Be $true
+            }
+        }
+    }
+}
+
+begin
+{
+    function Get-TestDscResourceModuleContent
+    {
+        $content = @'
+            function Get-TargetResource
+            {
+                [OutputType([hashtable])]
+                [CmdletBinding()]
+                param (
+                    [Parameter(Mandatory)]
+                    [string] $KeyProperty,
+
+                    [Parameter(Mandatory)]
+                    [string] $RequiredProperty
+                )
+
+                return @{
+                    KeyProperty      = $KeyProperty
+                    RequiredProperty = 'Required Property'
+                    WriteProperty    = 'Write Property'
+                    ReadProperty     = 'Read Property'
+                }
+            }
+
+            function Set-TargetResource
+            {
+                [CmdletBinding()]
+                param (
+                    [Parameter(Mandatory)]
+                    [string] $KeyProperty,
+
+                    [Parameter(Mandatory)]
+                    [string] $RequiredProperty,
+
+                    [string] $WriteProperty
+                )
+            }
+
+            function Test-TargetResource
+            {
+                [OutputType([bool])]
+                [CmdletBinding()]
+                param (
+                    [Parameter(Mandatory)]
+                    [string] $KeyProperty,
+
+                    [Parameter(Mandatory)]
+                    [string] $RequiredProperty,
+
+                    [string] $WriteProperty
+                )
+
+                return $false
+            }
+'@
+
+        return $content
+    }
+
+    function Get-TestDscResourceSchemaContent
+    {
+        $content = @'
+[ClassVersion("1.0.0"), FriendlyName("cTestResource")]
+class TestResource : OMI_BaseResource
+{
+    [Key] string KeyProperty;
+    [required] string RequiredProperty;
+    [write] string WriteProperty;
+    [read] string ReadProperty;
+};
+'@
+
+        return $content
+    }
+}


### PR DESCRIPTION
Refer to #1 for original comment history; this PR resubmitted to target the new dev branch.

This contains primarily updates to the Test-xDscResource functionality; other functions in the module are largely left alone.

The PowerShell.org community fork had a number of formatting changes (double quotes to single quotes, whitespace formatting, etc.)  I've tried to keep those changes out of this pull request, to keep the diff as easy to read as possible.

Summary of changes:

- Removed #Requires -RunAsAdministrator. The commands that require Administrator rights already check for it anyway, and this allows the rest of the module to be used from a normal PowerShell session.
- Added support for Enum types (with associated ValueMap)
- Added support for EmbeddedInstances other than MSFT_Credential and MSFT_KeyValuePair
- Fixed parameter name in Test-xDscResource comment-based help to match actual command definition
- Updated Test-xDscResource to use a process block, since it accepts pipeline input.
- Fixed invalid use of try/catch/finally in Test-MockSchema and Test-DscResourceModule
- Updated code related to Common parameters; now handles all common parameters properly based on command metadata.
- Added very basic tests for Test-xDscResource; these need to be fleshed out quite a bit later.