### PR TITLE
New-xDscResourceProperty parameter set fix

### DIFF
--- a/xDSCResourceDesigner.psm1
+++ b/xDSCResourceDesigner.psm1
@@ -308,7 +308,7 @@ Description : Ensure Present or Absent
 #>
 function New-xDscResourceProperty
 {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'ValidateSet')]
     [OutputType([Microsoft.PowerShell.xDesiredStateConfiguration.DscResourceProperty])]
     param
     (
@@ -343,11 +343,17 @@ function New-xDscResourceProperty
         [Microsoft.PowerShell.xDesiredStateConfiguration.DscResourcePropertyAttribute]
         $Attribute,
 
+        [Parameter(ParameterSetName = 'SupportsEnum')]
         [System.String[]]
         $ValueMap,
 
+        [Parameter(ParameterSetName = 'SupportsEnum')]
         [System.String[]]
         $Values,
+
+        [Parameter(ParameterSetName = 'ValidateSet')]
+        [System.String[]]
+        $ValidateSet,
 
         [System.String]
         $Description,
@@ -356,6 +362,12 @@ function New-xDscResourceProperty
         $ContainsEmbeddedInstance = $false
     )
     
+    if ($PSCmdlet.ParameterSetName -eq 'ValidateSet')
+    {
+        $Values = $ValidateSet
+        $ValueMap = $ValidateSet
+    }
+
     if ((Test-TypeIsArray $Type) -and [Microsoft.PowerShell.xDesiredStateConfiguration.DscResourcePropertyAttribute]::Key -eq $Attribute)
     {
         $errorId = "KeyArrayError"

--- a/xDscResourceDesigner.Tests.ps1
+++ b/xDscResourceDesigner.Tests.ps1
@@ -12,7 +12,8 @@ end
             Setup -File TestResource\TestResource.psm1 -Content (Get-TestDscResourceModuleContent)
 
             It 'Should fail the test' {
-                Test-xDscResource -Name $TestDrive\TestResource | Should Be $false
+                $result = Test-xDscResource -Name $TestDrive\TestResource
+                $result | Should Be $false
             }
         }
 
@@ -21,7 +22,8 @@ end
             Setup -File TestResource\TestResource.schema.mof -Content (Get-TestDscResourceSchemaContent)
 
             It 'Should fail the test' {
-                Test-xDscResource -Name $TestDrive\TestResource | Should Be $false
+                $result = Test-xDscResource -Name $TestDrive\TestResource
+                $result | Should Be $false
             }
         }
 
@@ -31,8 +33,58 @@ end
             Setup -File TestResource\TestResource.psm1 -Content (Get-TestDscResourceModuleContent)
 
             It 'Should pass the test' {
-                Test-xDscResource -Name $TestDrive\TestResource | Should Be $true
+                $result = Test-xDscResource -Name $TestDrive\TestResource
+                $result | Should Be $true
             }
+        }
+    }
+
+    Describe New-xDscResourceProperty {
+        $hash = @{ Result = $null }
+
+        It 'Allows the use of the ValidateSet parameter' {
+            $scriptBlock = {
+                $hash.Result = New-xDscResourceProperty  -Name Ensure  -Type String  -Attribute Required  -ValidateSet 'Present','Absent'
+            }
+
+            $scriptBlock | Should Not Throw
+            
+            $hash.Result.Values.Count | Should Be 2
+            $hash.Result.Values[0]    | Should Be 'Present'
+            $hash.Result.Values[1]    | Should Be 'Absent'
+            
+            $hash.Result.ValueMap.Count | Should Be 2
+            $hash.Result.ValueMap[0]    | Should Be 'Present'
+            $hash.Result.ValueMap[1]    | Should Be 'Absent'
+        }
+
+        It 'Allows the use of the ValueMap and Values parameters' {
+            $scriptBlock = {
+                $hash.Result = New-xDscResourceProperty  -Name Ensure  -Type String  -Attribute Required  -Values 'Present','Absent' -ValueMap 'Present','Absent'
+            }
+            
+            $scriptBlock | Should Not Throw
+            
+            $hash.Result.Values.Count | Should Be 2
+            $hash.Result.Values[0]    | Should Be 'Present'
+            $hash.Result.Values[1]    | Should Be 'Absent'
+            
+            $hash.Result.ValueMap.Count | Should Be 2
+            $hash.Result.ValueMap[0]    | Should Be 'Present'
+            $hash.Result.ValueMap[1]    | Should Be 'Absent'
+        }
+
+        It 'Does not allow ValidateSet and Values / ValueMap to be used together' {
+            $scriptBlock = {
+                New-xDscResourceProperty  -Name Ensure `
+                                          -Type String `
+                                          -Attribute Required `
+                                          -Values 'Present','Absent' `
+                                          -ValueMap 'Present','Absent' `
+                                          -ValidateSet 'Present', 'Absent'
+            }
+
+            $scriptBlock | Should Throw 'Parameter set cannot be resolved'
         }
     }
 }


### PR DESCRIPTION
The community updates to Test-xDscResource which added support for enumerated types also modified the interface to New-xDscResourceProperty (making the help content and examples for this command incorrect.)

The -ValidateSet parameter has been added back to this command via a new parameter set, while Test-xDscResource continues to be able to support enums where the Values / ValueMap arrays are not identical.

Still to do:  Write help content and examples for authoring DSC resources that use enums.  Possibly modify the interface for New-xDscResourceProperty as well to make this more friendly, if needed.
