### PR TITLE
Test-xDscSchemaEncoding now supports PowerShell Core - Fixes #64

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿[![Build status](https://ci.appveyor.com/api/projects/status/a98sv7wqd9trdc41/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xdscresourcedesigner/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/a98sv7wqd9trdc41/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xdscresourcedesigner/branch/master)
 
 # xDSCResourceDesigner
 
@@ -60,6 +60,8 @@ These uses of these functions are given below.
 
 ### Unreleased
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
+* Helper function Test-xDscSchemaEncoding now supports PowerShell Core (issue #64).
+* Changed README.md encoding to UTF8.
 
 ### 1.9.0.0
 

--- a/xDSCResourceDesigner.psm1
+++ b/xDSCResourceDesigner.psm1
@@ -2554,12 +2554,12 @@ function Test-TestHarness
     [CmdletBinding()]
     param
     ()
-    
-    if ($env:APPVEYOR) 
+
+    if ($env:APPVEYOR)
     {
         return $true
     }
-    
+
     return $false
 }
 
@@ -2578,7 +2578,21 @@ function Test-xDscSchemaEncoding
         $Schema
     )
 
-    $schemaBytes = Get-Content -Encoding Byte $Schema
+    $getContentParameters = @{
+        Path = $Schema
+    }
+
+    # Need to treat Windows Powershell and PowerShell Core different.
+    if ($PSVersionTable.PSEdition -eq 'Core')
+    {
+        $getContentParameters['AsByteStream'] = $true
+    }
+    else
+    {
+        $getContentParameters['Encoding'] = 'Byte'
+    }
+
+    $schemaBytes = Get-Content @getContentParameters
 
     # These are the UTF8 Byte Order Marks as read by PowerShell's Get-Content -Encoding Byte
     # [System.Text.Encoding]::UTF8.GetPreamble()

--- a/xDscResourceDesigner.Tests.ps1
+++ b/xDscResourceDesigner.Tests.ps1
@@ -44,6 +44,18 @@ end
                 $result | Should Be $true
             }
         }
+
+        Context 'A resource with both required files, but schema mof has encoding UTF8 BOM' {
+            Setup -Dir TestResource
+            Setup -File TestResource\TestResource.psm1 -Content (Get-TestDscResourceModuleContent)
+            Get-TestDscResourceSchemaContent |
+                Out-File -Encoding utf8 -FilePath (Join-Path -Path $TestDrive -ChildPath 'TestResource\TestResource.schema.mof') -Force
+
+            It 'Should write out the correct error to console, and pass the test' {
+                $result = Test-xDscResource -Name $TestDrive\TestResource
+                $result | Should Be $false
+            }
+        }
     }
 
     Describe New-xDscResourceProperty {

--- a/xDscResourceDesigner.Tests.ps1
+++ b/xDscResourceDesigner.Tests.ps1
@@ -46,14 +46,22 @@ end
         }
 
         Context 'A resource with both required files, but schema mof has encoding UTF8 BOM' {
+            BeforeAll {
+                Mock -CommandName 'Write-Error' -ModuleName 'xDscResourceDesigner'
+            }
+
             Setup -Dir TestResource
             Setup -File TestResource\TestResource.psm1 -Content (Get-TestDscResourceModuleContent)
             Get-TestDscResourceSchemaContent |
                 Out-File -Encoding utf8 -FilePath (Join-Path -Path $TestDrive -ChildPath 'TestResource\TestResource.schema.mof') -Force
 
-            It 'Should write out the correct error to console, and pass the test' {
+            It 'Should write out the correct error to console, and return $false' {
                 $result = Test-xDscResource -Name $TestDrive\TestResource
                 $result | Should Be $false
+
+                Assert-MockCalled -CommandName 'Write-Error' -ParameterFilter {
+                    $message -eq 'The encoding for the schema file is not supported. Please use Unicode or ASCII (Unicode is not well supported in GIT.)'
+                } -Exactly -Times 1 -ModuleName 'xDscResourceDesigner'
             }
         }
     }


### PR DESCRIPTION
- Changes to xDSCResourceDesigner
  - Helper function Test-xDscSchemaEncoding now supports PowerShell Core (issue #64).
  - Changed README.md encoding to UTF8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdscresourcedesigner/65)
<!-- Reviewable:end -->
