### PR TITLE
Workaround for Remove-WmiObject on PowerShell Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ These uses of these functions are given below.
 
 ### Unreleased
 
+* Fix Test-xDscSchema failing to call `Remove-WmiObject` on PowerShell Core.
+  As a workaround `Remove-WmiObject` is now called through Windows PowerShell on
+  PowerShell Core (issue #67).
+
 ### 1.10.0.0
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.
 * Helper function Test-xDscSchemaEncoding now supports PowerShell Core (issue #64).

--- a/xDscResourceDesigner.Tests.ps1
+++ b/xDscResourceDesigner.Tests.ps1
@@ -195,6 +195,46 @@ end
 
             }
         }
+
+        Describe 'Remove-DscCimClass' {
+            Context 'When calling from PowerShell Core' {
+                BeforeAll {
+                    # Mock PowerShell Core by changing the variable temporary-
+                    $script:previousPowerShellEdition = $PSVersionTable.PSEdition
+                    $PSVersionTable.PSEdition = 'Core'
+
+                    function powershell.exe
+                    {
+                    }
+
+                    Mock -CommandName 'powershell.exe'
+                    Mock -CommandName 'Invoke-Expression'
+                }
+
+                AfterAll {
+                    $PSVersionTable.PSEdition = $script:previousPowerShellEdition
+                }
+
+                It 'Should call through Windows PowerShell to remove the CIM class' {
+                    { Remove-DscCimClass -ClassName 'Dummy' -ErrorAction 'SilentlyContinue' } | Should -Not -Throw
+
+                    Assert-MockCalled -CommandName 'powershell.exe' -Exactly -Times 1
+                    Assert-MockCalled -CommandName 'Invoke-Expression' -Exactly -Times 0
+                }
+            }
+
+            Context 'When calling from Windows PowerShell' {
+                BeforeAll {
+                    Mock -CommandName 'Invoke-Expression'
+                }
+
+                It 'Should call Invoke-Expression to remove the CIM class' {
+                    { Remove-DscCimClass -ClassName 'Dummy' -ErrorAction 'SilentlyContinue' } | Should -Not -Throw
+
+                    Assert-MockCalled -CommandName 'Invoke-Expression' -Exactly -Times 1
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
- Fix Test-xDscSchema failing to call `Remove-WmiObject` on PowerShell Core.
  As a workaround `Remove-WmiObject` is now called through Windows PowerShell on
  PowerShell Core (issue #67).


Fixes #67

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdscresourcedesigner/68)
<!-- Reviewable:end -->
