### PR TITLE
Fix Test-xDscSchema failing to call Remove-WmiObject on PowerShell Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ These uses of these functions are given below.
 ### Unreleased
 
 * Added support for Codecov.
+* Fix Test-xDscSchema failing to call `Remove-WmiObject` on PowerShell Core.
+  The cmdlet `Remove-WmiObject` was removed from the code, instead the
+  temporary CIM class is now removed by using mofcomp.exe and the
+  preprocessor command [pragma deleteclass](https://msdn.microsoft.com/en-us/library/aa392751(v=vs.85).aspx)
+  (issue #67).
 
 ### 1.10.0.0
 * Converted appveyor.yml to install Pester from PSGallery instead of from Chocolatey.

--- a/xDSCResourceDesigner.psm1
+++ b/xDSCResourceDesigner.psm1
@@ -2535,10 +2535,19 @@ function Test-MockSchema
         }
         return ($errorIds.Length -eq 0)
     }
-    finally{
+    finally
+    {
         if ($newSchemaName)
         {
-            Remove-WmiObject -Class $newSchemaName -Namespace root\microsoft\windows\DesiredStateConfiguration -ErrorAction Ignore
+            Write-Verbose -Message ('Removing temporary CIM class ''{0}''.' -f $newSchemaName)
+            <#
+                Using mofcomp.exe and preprocessor command to delete an existing
+                class, and using 'nofail' flag so that no error is report if the
+                class does not exist. Assumed that it can be delete if the class
+                exist.
+            #>
+            Set-Content -Path $newSchemaPath -Value ('#pragma deleteclass("{0}",nofail)' -f $newSchemaName) -Force
+            & $mofcomp -N:root\microsoft\windows\DesiredStateConfiguration $newSchemaPath | Out-Null
         }
 
         if ($newSchemaPath)


### PR DESCRIPTION
- The cmdlet `Remove-WmiObject` was removed from the code, instead the
  temporary CIM class is now removed by using mofcomp.exe and the
  preprocessor command [pragma deleteclass](https://msdn.microsoft.com/en-us/library/aa392751(v=vs.85).aspx) (issue #67).

Fixes #67

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdscresourcedesigner/70)
<!-- Reviewable:end -->
