### PR TITLE
Fixes issue #73. Multiple classes in schema where last class doesnt match schema name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ These uses of these functions are given below.
 
 ### Unreleased
 
+* Fixed `Test-MockSchema` to return True if class name matches resource name when there are multiple embeded classes in the schema mof. [issue #123](https://github.com/PowerShell/xDSCResourceDesigner/issues/73).
+
 ### 1.11.0.0
 
 * Added support for Codecov.

--- a/Tests/xDscResourceDesigner.Tests.ps1
+++ b/Tests/xDscResourceDesigner.Tests.ps1
@@ -234,7 +234,11 @@ begin
                     [Parameter(Mandatory)]
                     [string] $RequiredProperty,
 
-                    [string] $WriteProperty
+                    [string] $WriteProperty,
+
+                    [Parameter()]
+                    [Microsoft.Management.Infrastructure.CimInstance]
+                    $SubClass
                 )
             }
 
@@ -249,7 +253,11 @@ begin
                     [Parameter(Mandatory)]
                     [string] $RequiredProperty,
 
-                    [string] $WriteProperty
+                    [string] $WriteProperty,
+
+                    [Parameter()]
+                    [Microsoft.Management.Infrastructure.CimInstance]
+                    $SubClass
                 )
 
                 return $false
@@ -269,7 +277,16 @@ class TestResource : OMI_BaseResource
     [required] string RequiredProperty;
     [write] string WriteProperty;
     [read] string ReadProperty;
+    [write, EmbeddedInstance("SubClass")] string SubClass;
 };
+
+[ClassVersion("1.0.0")]
+class SubClass
+{
+    [write] string WriteProperty1;
+    [write] string WriteProperty2;
+};
+
 '@
 
         return $content

--- a/xDSCResourceDesigner.psm1
+++ b/xDSCResourceDesigner.psm1
@@ -2428,15 +2428,15 @@ function Test-MockSchema
             if ($_ -cmatch "^class\s+([\w-&\(\)\[\]]+)\s*:?")
             {
                 $className = $Matches[1]
-                if($className -eq $schemaName)
-                {
-                    $classNameMatch = $true
-                }
             }
 
             if ($_ -cmatch "^class\s+$className\s*:\s*OMI_BaseResource")
             {
-                $extendsOMI = $true
+                $extendsOMI = $true                
+                if($className -eq $schemaName)
+                {
+                    $classNameMatch = $true
+                }
                 $newLine = $_ -replace $Matches[0],"class $newSchemaName"
             }
 

--- a/xDSCResourceDesigner.psm1
+++ b/xDSCResourceDesigner.psm1
@@ -2418,6 +2418,8 @@ function Test-MockSchema
 
         $extendsOMI = $false
 
+        $classNameMatch = $false;
+
         Get-Content $Schema | % {
             $newLine = $_
 
@@ -2426,6 +2428,10 @@ function Test-MockSchema
             if ($_ -cmatch "^class\s+([\w-&\(\)\[\]]+)\s*:?")
             {
                 $className = $Matches[1]
+                if($className -eq $schemaName)
+                {
+                    $classNameMatch = $true
+                }
             }
 
             if ($_ -cmatch "^class\s+$className\s*:\s*OMI_BaseResource")
@@ -2437,7 +2443,7 @@ function Test-MockSchema
             Add-Content $newSchemaPath $newLine
         }
 
-        if (-not $extendsOMI -or ($schemaName -ne $className))
+        if (-not $extendsOMI -or -not $classNameMatch)
         {
             $errorIds = @()
 


### PR DESCRIPTION
If you have multiple classes it will check the class with OMI_BaseResource matches the schema name.

Fixes: #73

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdscresourcedesigner/75)
<!-- Reviewable:end -->
