### PR TITLE
New-xDscResource: Change Dsc Module Validate Set Quotes to Singles

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ These uses of these functions are given below.
 
 ### Unreleased
 
+* New-xDscResource: Change Dsc Module Validate Set Quotes to Singles
+
 ### 1.12.0.0
 
 * Fixed `Test-MockSchema` to return True if class name matches resource name when there are multiple embeded classes in the schema mof. [issue #123](https://github.com/PowerShell/xDSCResourceDesigner/issues/73).

--- a/Tests/xDscResourceDesigner.Tests.ps1
+++ b/Tests/xDscResourceDesigner.Tests.ps1
@@ -196,6 +196,26 @@ end
 
             }
         }
+
+        Describe 'New-DelimitedList' {
+            It 'Should return the correct default single quote string list' {
+                $List = 'a','b','c'
+                $Result = New-DelimitedList $List -String
+                $Result | Should Be "'a','b','c'"
+            }
+
+            It 'Should return the correct single quote string list' {
+                $List = 'a','b','c'
+                $Result = New-DelimitedList $List -String -QuoteType Single
+                $Result | Should Be "'a','b','c'"
+            }
+
+            It 'Should return the correct double quote string list' {
+                $List = 'a','b','c'
+                $Result = New-DelimitedList $List -String -QuoteType Double
+                $Result | Should Be '"a","b","c"'
+            }
+        }
     }
 }
 

--- a/xDSCResourceDesigner.psm1
+++ b/xDSCResourceDesigner.psm1
@@ -870,7 +870,7 @@ function New-DscSchemaParameter
     {
         Add-StringBuilderLine $SchemaEntry ", ValueMap{" -Append
 
-        $CommaList = New-DelimitedList $Parameter.ValueMap -String:($Parameter.Type -eq "String" -or $Parameter.Type -eq "String[]")
+        $CommaList = New-DelimitedList $Parameter.ValueMap -String:($Parameter.Type -eq "String" -or $Parameter.Type -eq "String[]") -QuoteType Double
 
         Add-StringBuilderLine $SchemaEntry $CommaList -Append
         Add-StringBuilderLine $SchemaEntry "}" -Append
@@ -880,7 +880,7 @@ function New-DscSchemaParameter
     {
         Add-StringBuilderLine $SchemaEntry ", Values{" -Append
 
-        $CommaList = New-DelimitedList $Parameter.Values -String
+        $CommaList = New-DelimitedList $Parameter.Values -String -QuoteType Double
 
         Add-StringBuilderLine $SchemaEntry $CommaList -Append
         Add-StringBuilderLine $SchemaEntry "}" -Append
@@ -916,8 +916,23 @@ function New-DelimitedList
         $String,
 
         [String]
-        $Separator = ","
+        $Separator = ",",
+
+        [Parameter()]
+        [ValidateSet('Single', 'Double')]
+        [String]
+        $QuoteType = 'Single'
+
     )
+
+    if ($QuoteType -eq 'Single')
+    {
+        $Quote = ''''
+    }
+    else
+    {
+        $Quote = '"'
+    }
 
     $CommaList = New-Object -TypeName System.Text.StringBuilder
 
@@ -929,9 +944,9 @@ function New-DelimitedList
         #  the validateSet items need to be wrapped in quotes?
         if ($String)
         {
-            Add-StringBuilderLine $CommaList "`"" -Append
+            Add-StringBuilderLine $CommaList $Quote -Append
             Add-StringBuilderLine $CommaList $curItem -Append
-            Add-StringBuilderLine $CommaList "`"" -Append
+            Add-StringBuilderLine $CommaList $Quote -Append
         }
         else
         {
@@ -2432,7 +2447,7 @@ function Test-MockSchema
 
             if ($_ -cmatch "^class\s+$className\s*:\s*OMI_BaseResource")
             {
-                $extendsOMI = $true                
+                $extendsOMI = $true
                 if($className -eq $schemaName)
                 {
                     $classNameMatch = $true


### PR DESCRIPTION
#### Pull Request (PR) description

This PR  changes the quotes used around validate set values to be single quotes instead of double quotes to conform to [Dsc Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md#correct-use-of-single--and-double-quotes)

#### This Pull Request (PR) fixes the following issues

None

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your pull
    request (PR). For those task that don't apply to you pull request (PR),
    leave those as is.
-->
- [ ] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Documentation added/updated in README.md.
- [ ] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Unit tests added/updated.
- [x] New/changed code adheres to
      [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)
      and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdscresourcedesigner/83)
<!-- Reviewable:end -->
